### PR TITLE
Allow titlebar to be enabled via Xresources

### DIFF
--- a/partials/40_default-style
+++ b/partials/40_default-style
@@ -2,11 +2,13 @@
 floating_maximum_size -1 x -1
 for_window [class="floating_window"] floating enable
 
-# Disable titlebar
+# Set titlebar mode
+set_from_resource $i3-wm.floatingwindow.border.style i3-wm.floatingwindow.border.style pixel
 set_from_resource $i3-wm.floatingwindow.border.size i3-wm.floatingwindow.border.size 1
-default_floating_border pixel $i3-wm.floatingwindow.border.size
+default_floating_border $i3-wm.floatingwindow.border.style $i3-wm.floatingwindow.border.size
+set_from_resource $i3-wm.window.border.style i3-wm.window.border.style pixel
 set_from_resource $i3-wm.window.border.size i3-wm.window.border.size 1
-default_border pixel $i3-wm.window.border.size
+default_border $i3-wm.window.border.style $i3-wm.window.border.size
 
 # Enable popup during fullscreen
 set_from_resource $i3-wm.gaps.popup_during_fullscreen i3-wm.gaps.popup_during_fullscreen smart


### PR DESCRIPTION
Currently there isn't a way to enable the window titlebar without hacking at the `40_default-style` partial.

This PR adds two new Xresource definitions:

- `i3-wm.floatingwindow.border.style`
- `i3-wm.window.border.style`

These are defaulted to `pixel` to maintain the standard behaviour of no window titlebars, however a 'look' or a user can set them to `normal` to display window titlebars.

I was going to start working on a new look to emulate the default vanilla i3 appearance when I noticed that I couldn't add the titlebars.