### PR TITLE
Include plain user config file

### DIFF
--- a/config
+++ b/config
@@ -154,3 +154,4 @@ include /usr/share/regolith/i3/config.d/*
 
 # Include any user i3 partials
 include $HOME/.config/regolith2/i3/config.d/*
+include $HOME/.config/regolith2/i3/config


### PR DESCRIPTION
The [docs](https://regolith-desktop.com/docs/reference/configurations/) says this should be included, so either this file or the docs should change.