### PR TITLE
Update 55_session_keybindings

### DIFF
--- a/partials/55_session_keybindings
+++ b/partials/55_session_keybindings
@@ -6,6 +6,10 @@
 set_from_resource $i3-wm.binding.exit_app i3-wm.binding.exit_app Shift+q
 bindsym $mod+$i3-wm.binding.exit_app [con_id="__focused__"] kill
 
+## Session // Kill Parent // <><Ctrl> q ##
+set_from_resource $i3-wm.binding.kill_parent i3-wm.binding.kill_parent Ctrl+q
+bindsym $mod+$i3-wm.binding.kill_parent focus parent,kill
+
 ## Session // Terminate App // <><Alt> q ##
 set_from_resource $i3-wm.binding.kill_app i3-wm.binding.kill_app q
 bindsym $mod+$alt+$i3-wm.binding.kill_app [con_id="__focused__"] exec --no-startup-id kill -9 $(xdotool getwindowfocus getwindowpid)

--- a/partials/55_session_keybindings
+++ b/partials/55_session_keybindings
@@ -6,9 +6,9 @@
 set_from_resource $i3-wm.binding.exit_app i3-wm.binding.exit_app Shift+q
 bindsym $mod+$i3-wm.binding.exit_app [con_id="__focused__"] kill
 
-## Session // Kill Parent // <><Ctrl> q ##
-set_from_resource $i3-wm.binding.kill_parent i3-wm.binding.kill_parent Ctrl+q
-bindsym $mod+$i3-wm.binding.kill_parent focus parent,kill
+## Session // Exit apps in container // <><Ctrl> q ##
+set_from_resource $i3-wm.binding.exit_container i3-wm.binding.exit_container Ctrl+q
+bindsym $mod+$i3-wm.binding.exit_containter focus parent,kill
 
 ## Session // Terminate App // <><Alt> q ##
 set_from_resource $i3-wm.binding.kill_app i3-wm.binding.kill_app q


### PR DESCRIPTION
Adding a `kill_parent` binding, which kill the parent container of the currently focused window. With basic splits this means closing all apps in a workspace.