### PR TITLE
Make ilia launcher overrideable

### DIFF
--- a/partials/20_ilia
+++ b/partials/20_ilia
@@ -3,30 +3,30 @@ set_from_resource $ilia.stylesheet ilia.stylesheet
 
 ## Launch // Application // <> Space ##
 set_from_resource $i3-wm.binding.launcher.app i3-wm.binding.launcher.app space
-set_from_resource $i3-wm.program.launcher.app i3-wm.program.launcher.app ilia -p apps
-bindsym $mod+$i3-wm.binding.launcher.app exec --no-startup-id $i3-wm.program.launcher.app -t $ilia.stylesheet
+set_from_resource $i3-wm.program.launcher.app i3-wm.program.launcher.app ilia -p apps -t $ilia.stylesheet
+bindsym $mod+$i3-wm.binding.launcher.app exec --no-startup-id $i3-wm.program.launcher.app
 
 ## Launch // Command // <><Shift> Space ##
 set_from_resource $i3-wm.binding.launcher.cmd i3-wm.binding.launcher.cmd Shift+space
-set_from_resource $i3-wm.program.launcher.cmd i3-wm.program.launcher.cmd ilia -p terminal
-bindsym $mod+$i3-wm.binding.launcher.cmd exec --no-startup-id $i3-wm.program.launcher.cmd -t $ilia.stylesheet
+set_from_resource $i3-wm.program.launcher.cmd i3-wm.program.launcher.cmd ilia -p terminal -t $ilia.stylesheet
+bindsym $mod+$i3-wm.binding.launcher.cmd exec --no-startup-id $i3-wm.program.launcher.cmd
 
 ## Launch // Keybinding Viewer // <><Shift> ? ##
 set_from_resource $i3-wm.binding.help i3-wm.binding.help Shift+question
-set_from_resource $i3-wm.program.help i3-wm.program.help ilia -p keybindings
-bindsym $mod+$i3-wm.binding.help exec --no-startup-id $i3-wm.program.help -a -t $ilia.stylesheet
+set_from_resource $i3-wm.program.help i3-wm.program.help ilia -p keybindings -a -t $ilia.stylesheet
+bindsym $mod+$i3-wm.binding.help exec --no-startup-id $i3-wm.program.help
 
 ## Navigate // Window by Name // <><Ctrl> Space ##
 set_from_resource $i3-wm.binding.launcher.window i3-wm.binding.launcher.window Ctrl+space
-set_from_resource $i3-wm.program.launcher.window i3-wm.program.launcher.window ilia -p windows
-bindsym $mod+$i3-wm.binding.launcher.window exec --no-startup-id $i3-wm.program.launcher.window -t $ilia.stylesheet
+set_from_resource $i3-wm.program.launcher.window i3-wm.program.launcher.window ilia -p windows -t $ilia.stylesheet
+bindsym $mod+$i3-wm.binding.launcher.window exec --no-startup-id $i3-wm.program.launcher.window
 
 ## Launch // File Search // <><Alt> Space ##
 set_from_resource $i3-wm.binding.file_search i3-wm.binding.file_search space
-set_from_resource $i3-wm.program.file_search i3-wm.program.file_search ilia -p tracker
-bindsym $mod+$alt+$i3-wm.binding.file_search exec --no-startup-id $i3-wm.program.file_search -t $ilia.stylesheet
+set_from_resource $i3-wm.program.file_search i3-wm.program.file_search ilia -p tracker -t $ilia.stylesheet
+bindsym $mod+$alt+$i3-wm.binding.file_search exec --no-startup-id $i3-wm.program.file_search
 
 ## Launch // Look Selector // <><Alt> l ##
 set_from_resource $i3-wm.binding.look_selector i3-wm.binding.look_selector l
-set_from_resource $i3-wm.program.look_selector i3-wm.program.look_selector regolith-look-selector
-bindsym $mod+$alt+$i3-wm.binding.look_selector exec --no-startup-id $i3-wm.program.look_selector -t $ilia.stylesheet
+set_from_resource $i3-wm.program.look_selector i3-wm.program.look_selector regolith-look-selector -t $ilia.stylesheet
+bindsym $mod+$alt+$i3-wm.binding.look_selector exec --no-startup-id $i3-wm.program.look_selector


### PR DESCRIPTION
Currently if any `i3-wm.program.launcher.*` variable is overriden from Xresources, they take extra arguments that are probably not relevant.