### PR TITLE
add keybindings for screenshots

### DIFF
--- a/partials/61_screenshot_keybindings
+++ b/partials/61_screenshot_keybindings
@@ -1,0 +1,17 @@
+## Screenshot // Selection to File // Prtsc ##
+bindsym --release Print exec --no-startup-id "scrot -s -F ~/Pictures/screenshot_`date +%Y-%m-%d_%H:%M:%S_selection`.png"
+
+## Screenshot // Selection to Clipboard // <> Prtsc ##
+bindsym --release $mod+Print exec --no-startup-id "scrot -s - | xclip -selection clipboard -target image/png"
+
+## Screenshot // Window to File // Ctrl Prtsc ##
+bindsym --release Ctrl+Print exec --no-startup-id "scrot -u -F ~/Pictures/screenshot_`date +%Y-%m-%d_%H:%M:%S_window`.png"
+
+## Screenshot // Window to Clipboard // <> Ctrl Prtsc ##
+bindsym --release $mod+Ctrl+Print exec --no-startup-id "scrot -u - | xclip -selection clipboard -target image/png"
+
+## Screenshot // All to File// Shift Ctrl Prtsc ##
+bindsym --release Ctrl+Shift+Print exec --no-startup-id "scrot -F ~/Pictures/screenshot_`date +%Y-%m-%d_%H:%M:%S_all`.png"
+
+## Screenshot // All to Clipboard // <> Shift Ctrl Prtsc ##
+bindsym --release $mod+Ctrl+Shift+Print exec --no-startup-id "scrot - | xclip -selection clipboard -target image/png"


### PR DESCRIPTION
Adds keybindings to shot a selection, window or all to either file (generated name) or clipboard.

see also https://github.com/regolith-linux/regolith-desktop/issues/648

Is this OK here? 
Or was it already somewhere and I did not find it?
Or should this go into an own package/repo, because maybe someone do not want to have screenshots activated by default?
Do we want it this way?

Todo: 
- `scrot` and `xclip` is needed to make this work OOTB, I have no clue where to define these dependencies?

Some help needed.